### PR TITLE
Create API for managing load assignees

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -128,6 +128,8 @@ func main() {
 	apiProtected := e.Group("/api")
 	apiProtected.Use(middleware.APIKeyAuth(cfg.APIKey))
 	apiProtected.POST("/loads/upsert", apiHandler.UpsertLoad)
+	apiProtected.POST("/loads/:id/assignees", apiHandler.AddAssigneesToLoad)
+	apiProtected.DELETE("/loads/:id/assignees/:email", apiHandler.RemoveAssigneeFromLoad)
 	apiProtected.POST("/entities", apiHandler.CreateEntity)
 	apiProtected.DELETE("/entities/:id", apiHandler.DeleteEntity)
 	apiProtected.GET("/groups/:id/members", apiHandler.GetGroupMembers)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -139,3 +139,11 @@ type WebhookAlertPayload struct {
 type AddGroupMemberRequest struct {
 	PersonEmail string `json:"person_email" validate:"required,email"`
 }
+
+// AddAssigneeRequest is the request body for adding assignee(s) to a load
+type AddAssigneeRequest struct {
+	Assignees []struct {
+		Email  string  `json:"email" validate:"required,email"`
+		Weight float64 `json:"weight,omitempty"` // Default 1.0
+	} `json:"assignees" validate:"required,min=1,dive"`
+}

--- a/internal/service/load.go
+++ b/internal/service/load.go
@@ -91,3 +91,67 @@ func (s *LoadService) GetLoadsByDateRange(ctx context.Context, start, end time.T
 func (s *LoadService) DeleteLoad(ctx context.Context, id int) error {
 	return s.loadRepo.Delete(ctx, id)
 }
+
+// AddAssignees adds one or more assignees to an existing load
+func (s *LoadService) AddAssignees(ctx context.Context, loadID int, req *models.AddAssigneeRequest) error {
+	// First, verify the load exists
+	load, err := s.loadRepo.GetByID(ctx, loadID)
+	if err != nil {
+		return fmt.Errorf("load not found: %w", err)
+	}
+
+	// Validate all assignees exist
+	for _, a := range req.Assignees {
+		exists, err := s.entityRepo.Exists(ctx, a.Email)
+		if err != nil {
+			return fmt.Errorf("failed to check assignee: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("assignee not found: %s", a.Email)
+		}
+	}
+
+	// Build assignments
+	assignments := make([]models.LoadAssignment, 0, len(req.Assignees))
+	for _, a := range req.Assignees {
+		weight := a.Weight
+		if weight == 0 {
+			weight = 1.0 // Default weight
+		}
+		assignments = append(assignments, models.LoadAssignment{
+			LoadID:      loadID,
+			PersonEmail: a.Email,
+			Weight:      weight,
+		})
+	}
+
+	// Add assignments
+	err = s.loadRepo.AddAssignees(ctx, loadID, assignments)
+	if err != nil {
+		return fmt.Errorf("failed to add assignees: %w", err)
+	}
+
+	// Trigger webhook alerts for affected persons (in background)
+	for _, a := range req.Assignees {
+		s.webhookService.CheckAndAlert(a.Email, load.Load.Date)
+	}
+
+	return nil
+}
+
+// RemoveAssignee removes a specific assignee from a load
+func (s *LoadService) RemoveAssignee(ctx context.Context, loadID int, personEmail string) error {
+	// Verify the load exists
+	_, err := s.loadRepo.GetByID(ctx, loadID)
+	if err != nil {
+		return fmt.Errorf("load not found: %w", err)
+	}
+
+	// Remove the assignee
+	err = s.loadRepo.RemoveAssignee(ctx, loadID, personEmail)
+	if err != nil {
+		return fmt.Errorf("failed to remove assignee: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Implemented two new API endpoints for managing load assignees:
- POST /api/loads/:id/assignees - Add one or more assignees to a load
- DELETE /api/loads/:id/assignees/:email - Remove an assignee from a load

Changes include:
- Added AddAssigneeRequest model for request validation
- Implemented repository methods: AddAssignees and RemoveAssignee
- Implemented service layer with validation and webhook triggers
- Added handler methods with comprehensive Swagger documentation
- Registered new routes in protected API group (requires x-api-key)

The AddAssignees endpoint uses INSERT ON CONFLICT to handle duplicate assignments, updating the weight if the assignee already exists. Both endpoints validate that the load exists and trigger webhook alerts when assignees are added.