### PR TITLE
Add URL tracking for external platform loads

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -43,6 +43,7 @@ func (db *DB) RunMigrations(ctx context.Context) error {
 		external_id TEXT UNIQUE,
 		title TEXT NOT NULL,
 		source TEXT,
+		url TEXT,
 		date DATE NOT NULL
 	);
 
@@ -53,6 +54,17 @@ func (db *DB) RunMigrations(ctx context.Context) error {
 		weight FLOAT DEFAULT 1.0,
 		PRIMARY KEY (load_id, person_email)
 	);
+
+	-- Add URL column to loads table if it doesn't exist (migration for existing databases)
+	DO $$
+	BEGIN
+		IF NOT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name='loads' AND column_name='url'
+		) THEN
+			ALTER TABLE loads ADD COLUMN url TEXT;
+		END IF;
+	END $$;
 
 	-- Create indexes for performance
 	CREATE INDEX IF NOT EXISTS idx_loads_date ON loads(date);

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -40,6 +40,7 @@ type Load struct {
 	ExternalID *string   `json:"external_id,omitempty"` // For n8n/external system deduplication
 	Title      string    `json:"title"`
 	Source     *string   `json:"source,omitempty"` // Origin system (gcal, crm, etc.)
+	URL        *string   `json:"url,omitempty"`    // Link back to original platform (gcal, lark, etc.)
 	Date       time.Time `json:"date"`
 }
 
@@ -91,6 +92,7 @@ type UpsertLoadRequest struct {
 	ExternalID string `json:"external_id" validate:"required"`
 	Title      string `json:"title" validate:"required"`
 	Source     string `json:"source,omitempty"`
+	URL        string `json:"url,omitempty"` // Link back to original platform
 	Date       string `json:"date" validate:"required"` // Format: YYYY-MM-DD
 	Assignees  []struct {
 		Email  string  `json:"email" validate:"required,email"`

--- a/internal/service/load.go
+++ b/internal/service/load.go
@@ -49,10 +49,12 @@ func (s *LoadService) UpsertLoad(ctx context.Context, req *models.UpsertLoadRequ
 	// Build load and assignments
 	externalID := req.ExternalID
 	source := req.Source
+	url := req.URL
 	load := &models.Load{
 		ExternalID: &externalID,
 		Title:      req.Title,
 		Source:     &source,
+		URL:        &url,
 		Date:       date,
 	}
 

--- a/templates/partials/day_tasks.html
+++ b/templates/partials/day_tasks.html
@@ -33,7 +33,18 @@
             <div class="border border-gray-200 rounded-lg p-4 bg-gray-50 hover:bg-gray-100 transition-colors">
                 <div class="flex justify-between items-center">
                     <div class="flex-1">
+                        {{if .Load.URL}}
+                        <h5 class="font-medium text-blue-600 hover:text-blue-800">
+                            <a href="{{.Load.URL}}" target="_blank" rel="noopener noreferrer" class="flex items-center gap-1">
+                                {{.Load.Title}}
+                                <svg class="w-4 h-4 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+                                </svg>
+                            </a>
+                        </h5>
+                        {{else}}
                         <h5 class="font-medium text-gray-800">{{.Load.Title}}</h5>
+                        {{end}}
                         {{if .Load.Source}}
                         <p class="text-xs text-gray-500 mt-1">Source: {{.Load.Source}}</p>
                         {{end}}


### PR DESCRIPTION
This commit adds URL field to loads to enable tracking back to external platforms like Google Calendar, Lark tasks, etc.

Changes:
- Add URL field to Load model and UpsertLoadRequest
- Update database migration to include URL column
- Add migration logic for existing databases
- Update all repository methods to handle URL field (UpsertByExternalID, GetByID, GetLoadsByDateRange, GetLoadsForEntityOnDate)
- Update LoadService to pass URL from request to repository
- Update day_tasks template to display load title as clickable link when URL is present
- Add external link icon to indicate URL opens in new tab

The URL is optional and will be displayed as a clickable link in the UI when provided, allowing users to quickly navigate to the original source.