### PR TITLE
Move database tables to custom schema

### DIFF
--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -25,6 +26,12 @@ func New(databaseURL string) (*DB, error) {
 	config.MinConns = 5
 	config.MaxConnLifetime = time.Hour
 	config.MaxConnIdleTime = 30 * time.Minute
+
+	// Set search_path to use custom schema for this application
+	config.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, "SET search_path TO load_calendar_data, public")
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
To support sharing the database with other applications, all tables now use a custom 'load_calendar_data' schema instead of the default 'public' schema.

Changes:
- Created 'load_calendar_data' schema in migrations
- Updated all CREATE TABLE statements to use schema prefix
- Updated all foreign key references to use schema-qualified table names
- Updated all CREATE INDEX statements to use schema-qualified table names
- Updated information_schema query to check for schema-qualified columns
- Set search_path to 'load_calendar_data, public' in database connection
- Updated all seed data queries to use schema-qualified table names

The search_path configuration ensures that existing repository queries continue to work without modification, as unqualified table names will automatically resolve to the load_calendar_data schema first.