### PR TITLE
Replace email OTP with API call for password reset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 DATABASE_URL=postgres://user:pass@localhost:5432/heatmap?sslmode=disable
 API_KEY=your-secure-api-key
 SESSION_SECRET=your-32-byte-secret-key-here!!!!
-MAILGUN_API_KEY=your-mailgun-api-key
-MAILGUN_DOMAIN=mg.yourdomain.com
+LARK_BEARER_TOKEN=your-lark-bearer-token-from-app-credentials
 WEBHOOK_DESTINATION_URL=https://n8n.yourdomain.com/webhook/alerts
 PORT=8080

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -76,7 +76,7 @@ func main() {
 	webhookService := service.NewWebhookService(cfg.WebhookDestinationURL, loadRepo, capacityRepo)
 	heatmapService := service.NewHeatmapService(entityRepo, capacityRepo, loadRepo, groupRepo)
 	loadService := service.NewLoadService(loadRepo, entityRepo, webhookService)
-	authService := service.NewAuthService(db.Pool, cfg.MailgunDomain, cfg.MailgunAPIKey)
+	authService := service.NewAuthService(db.Pool, cfg.LarkBearerToken)
 	capacityService := service.NewCapacityService(entityRepo, capacityRepo)
 
 	// Load templates

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.15.0
-	github.com/mailgun/mailgun-go/v4 v4.23.0
 	github.com/swaggo/echo-swagger v1.4.1
 )
 
@@ -32,7 +31,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/mailgun/errors v0.4.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,8 +10,7 @@ type Config struct {
 	DatabaseURL           string
 	APIKey                string
 	SessionSecret         string
-	MailgunAPIKey         string
-	MailgunDomain         string
+	LarkBearerToken       string
 	WebhookDestinationURL string
 	Port                  string
 }
@@ -24,8 +23,7 @@ func Load() (*Config, error) {
 		DatabaseURL:           getEnv("DATABASE_URL", "postgres://localhost:5432/load_calendar?sslmode=disable"),
 		APIKey:                getEnv("API_KEY", ""),
 		SessionSecret:         getEnv("SESSION_SECRET", "default-secret-change-in-production"),
-		MailgunAPIKey:         getEnv("MAILGUN_API_KEY", ""),
-		MailgunDomain:         getEnv("MAILGUN_DOMAIN", ""),
+		LarkBearerToken:       getEnv("LARK_BEARER_TOKEN", ""),
 		WebhookDestinationURL: getEnv("WEBHOOK_DESTINATION_URL", ""),
 		Port:                  getEnv("PORT", "8080"),
 	}


### PR DESCRIPTION
- Replace Mailgun environment variables with LARK_BEARER_TOKEN
- Update AuthService to use Lark API for sending OTP codes
- Replace sendOTPEmail with sendOTPViaLark function
- Remove Mailgun dependency from go.mod
- Update .env.example with new Lark configuration

The OTP is now sent via Lark's messaging API instead of email, allowing users to receive OTP codes through Lark messages.